### PR TITLE
Fixed and updated parts of the operation that were causing problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,28 @@ within the ```$casts``` array, as shown below:
   ];
 ```
 
+In the case where you would like the user to be able to specify a comma seperated list of any values. You can
+add the following to the CRUD column config.
+
+```php
+CRUD::addColumn([
+   'name' => 'type',
+   'label' => 'Customer Type',
+   'type' => 'array',
+   'multiple' => true,
+   'options' => 'any'
+]);  
+```
+With this configuration, the user could put whatever they like.
+For example, if they imported dog,cat,rat - It would be saved to the model as:
+```php
+[
+    'dog',
+    'cat',
+    'rat'
+]
+```
+
 ## Primary Keys
 
 The import operation needs to know your model's primary key

--- a/README.md
+++ b/README.md
@@ -430,7 +430,8 @@ the ```getName()``` function in your column.
 **Step 2.**
 
 Add your new class to the file at ```config/backpack/operations/import.php``` under
-the ```'column_aliases'``` array:
+the ```'column_aliases'``` array. The key should be what you specify as the column type in
+```setupImportOperation```
 
 ```php
     //...
@@ -441,7 +442,7 @@ the ```'column_aliases'``` array:
         'date' => Columns\DateColumn::class,
         'number' => Columns\NumberColumn::class,
         'text' => Columns\TextColumn::class,
-        'example' => App\ImportColumns\ExampleColumn::class
+        'column_type' => App\Imports\Columns\ExampleColumn::class
     ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,15 +44,16 @@ the same syntax as you would to define your list views.
 7. [Adding Your Own Columns](#adding-your-own-columns)
 8. [Custom Import Classes](#custom-import-classes)
 9. [Disabling User Mapping](#disabling-user-mapping)
-10. [Queued Imports](#queued-imports)
-11. [Configuration](#configuration)
+10. [Delete Spreadsheet on Completion](#delete-spreadsheet-on-completion)
+11. [Queued Imports](#queued-imports)
+12. [Configuration](#configuration)
     1. [File Uploads](#file-uploads)
     2. [Queues](#queues)
     3. [Changing the Import log Model](#import-log)
     4. [Customising Translations](#translations)
     5. [Customising Views](#views)
-12. [Credits](#credits)
-13. [License](#license)
+13. [Credits](#credits)
+14. [License](#license)
 
 ## Installation
 
@@ -538,6 +539,19 @@ of code to the ```setupImportOperation()``` function:
     protected function setupImportOperation()
     {
         $this->disableUserMapping();
+    //...
+```
+
+## Delete Spreadsheet on Completion
+By default, the uploaded spreadsheet will remain in storage after an import is completed.
+This is useful for debugging/logging purposes but may not suit your requirements.
+If you would like your file to be deleted after an import is complete, add this one line
+of code to the ```setupImportOperation()``` function:
+```php
+  //...
+    protected function setupImportOperation()
+    {
+        $this->deleteFileAfterImport();
     //...
 ```
 

--- a/README.md
+++ b/README.md
@@ -338,6 +338,14 @@ For example, if they imported dog,cat,rat - It would be saved to the model as:
 ]
 ```
 
+```'options' => 'any'``` 
+
+cannot be used without
+
+```'multiple' => true ```
+
+as it does not make sense for this column type. In this case, just use a text column.
+
 ## Primary Keys
 
 The import operation needs to know your model's primary key

--- a/database/migrations/2024_01_17_200118_add_delete_file_after_import_column_to_import_log_table.php
+++ b/database/migrations/2024_01_17_200118_add_delete_file_after_import_column_to_import_log_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('import_log', function (Blueprint $table) {
+            $table->boolean('delete_file_after_import')->after('config')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('import_log', function (Blueprint $table) {
+            $table->dropColumn('delete_file_after_import');
+        });
+    }
+};

--- a/resources/views/confirm-import.blade.php
+++ b/resources/views/confirm-import.blade.php
@@ -59,64 +59,53 @@
                             <h5>
                                 @lang('import-operation::import.confirm_your_import')
                             </h5>
-                            @include('import-operation::inc.mapper-headings')
-                            <div class="border p-1" style="height: 50vh; overflow-y: auto; overflow-x:hidden">
-                                @foreach($import->config as $heading => $column)
-                                    <div class="row mb-2">
-                                        <div class="col-md-6">
-                                            <div class="card" style="height: 100%;">
-                                                <div
-                                                    class="card-body py-0 d-flex flex-column justify-content-center px-3">
-                                                    <p class="font-xl m-0">
-                                                        {{ ucfirst(str_replace('_', ' ', $heading)) }}
-                                                    </p>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="col-md-2">
-                                            <div class="card" style="height: 100%;">
-                                                <div
-                                                    class="card-body py-0 d-flex flex-column align-items-center justify-content-center py-1 px-3">
-                                                    <i class="las la-arrow-right d-none d-md-block font-5xl text-muted"></i>
-                                                    <i class="las la-arrow-down d-md-none font-5xl text-muted"></i>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="col-md-4">
-                                            <div
-                                                class="card @if($column['name'] === $import->model_primary_key) border-primary @endif"
-                                                style="height: 100%;">
-                                                <div
-                                                    class="card-body py-0 d-flex flex-column justify-content-center px-3">
-                                                    <p class="text-uppercase text-muted m-0 font-xs">
-                                                        {{ $crud->entity_name }}
-                                                    </p>
-                                                    <h4 class="m-0 font-xl">
-                                                        {{ $column['label'] }}
-                                                    </h4>
-                                                    <strong class="text-muted">
-                                                        @if(in_array($column['type'], array_keys(config('backpack.operations.import.column_aliases'))))
-                                                            @php
-                                                                $aliases = config('backpack.operations.import.column_aliases');
-                                                                $class = $aliases[$column['type']];
-                                                            @endphp
 
-                                                            {{ (new $class(''))->getName() }}
-                                                        @else
-                                                            {{ (new $column['type'](''))->getName() }}
-                                                        @endif
-                                                        @if($column['name'] === $import->model_primary_key)
-                                                            <small class="text-primary">
-                                                                [@lang('import-operation::import.primary_key')]
-                                                            </small>
-                                                        @endif
-                                                    </strong>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                @endforeach
-                            </div>
+                            <table
+                                class="table  nowrap rounded card-table table-vcenter card-table shadow-xs border-xs">
+                                <thead>
+                                <tr>
+                                    <th>
+                                        @lang('import-operation::import.import_data_from')
+                                    </th>
+                                    <th colspan="2">
+                                        @lang('import-operation::import.into_field')
+                                    </th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                @foreach($import->config as $heading => $columns)
+                                    @foreach($columns as $column)
+                                        <tr>
+                                            @if($loop->index === 0)
+                                                <td class="border-right" rowspan="{{ count($columns) }}">
+                                                    {{ ucfirst(str_replace('_', ' ', $heading)) }}
+                                                </td>
+                                            @endif
+                                            <td>
+                                                {{ $column['label'] }}
+                                            </td>
+                                            <td>
+                                                @if(in_array($column['type'], array_keys(config('backpack.operations.import.column_aliases'))))
+                                                    @php
+                                                        $aliases = config('backpack.operations.import.column_aliases');
+                                                        $class = $aliases[$column['type']];
+                                                    @endphp
+
+                                                    {{ (new $class(''))->getName() }}
+                                                @else
+                                                    {{ (new $column['type'](''))->getName() }}
+                                                @endif
+                                                @if($column['name'] === $import->model_primary_key)
+                                                    <small class="text-primary">
+                                                        [@lang('import-operation::import.primary_key')]
+                                                    </small>
+                                                @endif
+                                            </td>
+                                        </tr>
+                                        @endforeach
+                                    @endforeach
+                                </tbody>
+                            </table>
                             <div class="mt-2">
                                 @if($import->file_url)
                                     <a title="@lang('import-operation::import.click_here_to_download_file')"

--- a/src/Columns/ArrayColumn.php
+++ b/src/Columns/ArrayColumn.php
@@ -15,22 +15,27 @@ class ArrayColumn extends ImportColumn
         $options = $this->getConfig('options');
 
         if ($options) {
-            if ($multiple){
+            if ($multiple) {
                 $values = [];
                 $data_split = explode($separator, $this->data);
-                foreach($data_split as $data_value){
-                    foreach ($options as $value => $option) {
-                        if ($option === $data_value) {
-                            $values[] = $value;
+                foreach ($data_split as $data_value) {
+                    if (is_array($options)) {
+                        foreach ($options as $value => $option) {
+                            if ($option === $data_value) {
+                                $values[] = $value;
+                            }
                         }
+                    } else if ($options === 'any') {
+                        $values[] = $data_value;
                     }
                 }
                 return $values;
-            }
-            else{
-                foreach ($options as $value => $option) {
-                    if ($option === $this->data) {
-                        return $value;
+            } else {
+                if (is_array($options)) {
+                    foreach ($options as $value => $option) {
+                        if ($option === $this->data) {
+                            return $value;
+                        }
                     }
                 }
             }

--- a/src/ImportOperation.php
+++ b/src/ImportOperation.php
@@ -323,7 +323,7 @@ trait ImportOperation
         $log->save();
 
         $import_should_queue = $this->crud->getOperationSetting('queueImport', 'import') ?? false;
-        $import_class = $import_should_queue ? CrudImport::class : QueuedCrudImport::class;
+        $import_class = $import_should_queue ? QueuedCrudImport::class : CrudImport::class;
 
         //Set custom import class if it has been specified
         if (!is_null($this->custom_import_handler)) {

--- a/src/ImportOperation.php
+++ b/src/ImportOperation.php
@@ -124,6 +124,15 @@ trait ImportOperation
     }
 
     /**
+     * Delete the spreadsheet file after an import is complete
+     * @return void
+     */
+    public function deleteFileAfterImport(): void
+    {
+        CRUD::setOperationSetting('deleteFileAfterImport', true);
+    }
+
+    /**
      * Set a custom import class, this will skip the mapping phase on the front end
      * @param string $import_class
      * @return void
@@ -318,6 +327,11 @@ trait ImportOperation
         }
 
         $formRequest = $this->crud->getFormRequest();
+
+        $file_should_be_deleted = $this->crud->getOperationSetting('deleteFileAfterImport', 'import') ?? false;
+        if ($file_should_be_deleted){
+            $log->delete_file_after_import = true;
+        }
 
         $log->started_at = Carbon::now();
         $log->save();

--- a/src/ImportOperation.php
+++ b/src/ImportOperation.php
@@ -210,7 +210,7 @@ trait ImportOperation
         if ($user_mapping_disabled){
             $config = [];
             foreach($this->crud->columns() as $column){
-                $config[$column['name']] = $column;
+                $config[$column['name']] = [$column];
             }
             $log->config = $config;
             $log->save();

--- a/src/ImportOperation.php
+++ b/src/ImportOperation.php
@@ -264,9 +264,13 @@ trait ImportOperation
 
         $config = [];
         foreach ($this->crud->columns() as $column) {
-            $chosen_field = $request->get($column['name'] . '__heading');
-            if ($chosen_field) {
-                $config[$chosen_field] = collect($column)->filter(
+            $chosen_heading = $request->get($column['name'] . '__heading');
+            if ($chosen_heading) {
+                if (!isset($config[$chosen_heading])){
+                    $config[$chosen_heading] = [];
+                }
+
+                $config[$chosen_heading][] = collect($column)->filter(
                     fn($value, $key) => in_array($key, [
                             'name', 'label', 'type', 'primary_key', 'options', 'separator', 'multiple',
                         ]
@@ -280,8 +284,8 @@ trait ImportOperation
             ]);
         }
 
-        if (is_null(collect($config)->filter(function($item) use($log){
-            return $item['name'] === $log->model_primary_key;
+        if (is_null(collect($config)->filter(function($items) use($log){
+            return collect($items)->where('name', $log->model_primary_key)->count() > 0;
         })->first())) {
             return redirect($this->crud->route . '/import/' . $id . '/map')->withErrors([
                 'import' => __('import-operation::import.please_map_the_primary_key'),

--- a/src/Imports/CrudImport.php
+++ b/src/Imports/CrudImport.php
@@ -4,6 +4,7 @@ namespace RedSquirrelStudio\LaravelBackpackImportOperation\Imports;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Facades\Validator;
 use Maatwebsite\Excel\Concerns\OnEachRow;
 use Maatwebsite\Excel\Concerns\WithEvents;
@@ -198,6 +199,10 @@ class CrudImport implements WithCrudSupport, OnEachRow, WithHeadingRow, WithEven
                 $log = $importer->getImportLog();
                 $log->completed_at = Carbon::now();
                 $log->save();
+
+                if ($log->delete_file_after_import){
+                    Storage::disk($log->disk)->delete($log->file_path);
+                }
             },
         ];
     }

--- a/src/Imports/CrudImport.php
+++ b/src/Imports/CrudImport.php
@@ -76,7 +76,7 @@ class CrudImport implements WithCrudSupport, OnEachRow, WithHeadingRow, WithEven
             if ($matched_config && count($handler_classes) === count($matched_config)) {
                 foreach($handler_classes as $index => $handler_class){
                     //Instantiate handler class, process data from column
-                    $handler = new $handler_class($value, $matched_config, $this->import_log->model);
+                    $handler = new $handler_class($value, $matched_config[$index], $this->import_log->model);
                     $data = $handler->output();
 
                     //Assign the data to the model field specified in config

--- a/src/Imports/CrudImport.php
+++ b/src/Imports/CrudImport.php
@@ -71,15 +71,18 @@ class CrudImport implements WithCrudSupport, OnEachRow, WithHeadingRow, WithEven
             $data = null;
             //Get the config that matches the current column heading
             $matched_config = $this->getMatchedConfig($heading);
-            $handler_class = $this->getColumnHandlerClass($matched_config);
-            if ($matched_config && $handler_class) {
-                //Instantiate handler class, process data from column
-                $handler = new $handler_class($value, $matched_config, $this->import_log->model);
-                $data = $handler->output();
+            $handler_classes = $this->getColumnHandlerClasses($matched_config);
 
-                //Assign the data to the model field specified in config
-                $model_field = $matched_config['name'];
-                $entry->{$model_field} = $data;
+            if ($matched_config && count($handler_classes) === count($matched_config)) {
+                foreach($handler_classes as $index => $handler_class){
+                    //Instantiate handler class, process data from column
+                    $handler = new $handler_class($value, $matched_config, $this->import_log->model);
+                    $data = $handler->output();
+
+                    //Assign the data to the model field specified in config
+                    $model_field = $matched_config[$index]['name'];
+                    $entry->{$model_field} = $data;
+                }
             }
         }
         //Save the entry
@@ -116,8 +119,8 @@ class CrudImport implements WithCrudSupport, OnEachRow, WithHeadingRow, WithEven
         $primary_key = $this->import_log->model_primary_key;
 
         $primary_column_header = null;
-        foreach ($this->import_log->config as $column_header => $column_config) {
-            if ($column_config['name'] === $primary_key) {
+        foreach ($this->import_log->config as $column_header => $column_configs) {
+            if (collect($column_configs)->where('name', $primary_key)->count() > 0) {
                 $primary_column_header = $column_header;
             }
         }
@@ -128,12 +131,11 @@ class CrudImport implements WithCrudSupport, OnEachRow, WithHeadingRow, WithEven
      * @param array $row
      * @return array
      */
-    //Only handle columns that have been mapped, exclude the primary key
+    //Only handle columns that have been mapped
     protected function filterRow(array $row): array
     {
         return collect($row)->filter(function ($column, $heading) {
-            $primary_column_header = $this->getPrimaryKeyColumnHeader();
-            return $heading !== $primary_column_header && in_array($heading, array_keys($this->import_log->config));
+            return in_array($heading, array_keys($this->import_log->config));
         })->toArray();
     }
 
@@ -161,22 +163,26 @@ class CrudImport implements WithCrudSupport, OnEachRow, WithHeadingRow, WithEven
 
     /**
      * @param array|null $matched_config
-     * @return string|null
+     * @return array{string}
      */
-    protected function getColumnHandlerClass(?array $matched_config = null): ?string
+    protected function getColumnHandlerClasses(?array $matched_config = null): array
     {
+        $columns_types = [];
         if ($matched_config) {
-            if (!isset($matched_config['type'])) {
-                return TextColumn::class;
-            }
-            if (in_array($matched_config['type'], array_keys(config('backpack.operations.import.column_aliases')))) {
-                $aliases = config('backpack.operations.import.column_aliases');
-                return $aliases[$matched_config['type']];
-            } else {
-                return $matched_config['type'];
+            foreach($matched_config as $matched_config_column){
+                if (!isset($matched_config_column['type'])) {
+                    $column_types[] = TextColumn::class;
+                }
+                if (in_array($matched_config_column['type'], array_keys(config('backpack.operations.import.column_aliases')))) {
+                    $aliases = config('backpack.operations.import.column_aliases');
+                    $column_types[] = $aliases[$matched_config_column['type']];
+                } else {
+                    $column_types[] = $matched_config_column['type'];
+                }
             }
         }
-        return TextColumn::class;
+
+        return $column_types;
     }
 
 

--- a/src/Models/ImportLog.php
+++ b/src/Models/ImportLog.php
@@ -22,11 +22,15 @@ class ImportLog extends Model
     protected $primaryKey = 'id';
     public $timestamps = true;
     protected $guarded = ['id'];
-    protected $fillable = ['user_id', 'file_path', 'disk', 'model_primary_key', 'model', 'config', 'started_at', 'completed_at'];
+    protected $fillable = [
+        'user_id', 'file_path', 'disk', 'model_primary_key', 'model',
+        'config', 'delete_file_after_import', 'started_at', 'completed_at'
+    ];
     protected $casts = [
         'config' => 'array',
         'started_at' => 'datetime',
         'completed_at' => 'datetime',
+        'delete_file_after_import' => 'boolean',
     ];
 
     /*


### PR DESCRIPTION
- Queued imports have been fixed
- The array column now supports 'options' => 'any' when 'multiple' is set to true, this allows any comma separated values to be imported.
- $this->deleteFileAfterImport(); can be added to the setup function to delete the file after import.
- The README has been updated to make adding the custom column alias more clear.
- You can now import the same spreadsheet column into multiple model fields.
