### PR TITLE
Save all column attributes when creating import log

### DIFF
--- a/src/ImportOperation.php
+++ b/src/ImportOperation.php
@@ -288,11 +288,7 @@ trait ImportOperation
                     $config[$chosen_heading] = [];
                 }
 
-                $config[$chosen_heading][] = collect($column)->filter(
-                    fn($value, $key) => in_array($key, [
-                            'name', 'label', 'type', 'primary_key', 'options', 'separator', 'multiple',
-                        ]
-                    ))->toArray();
+                $config[$chosen_heading][] = collect($column)->toArray();
             }
         }
 


### PR DESCRIPTION
All column attributes are now saved against an import so that custom columns have more control over what attributes they would like to use.